### PR TITLE
fix: use infura secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
         run: yarn test
         env:
           INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+          INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
         
       - name: Build source
         run: yarn build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,6 +32,7 @@ jobs:
         run: yarn test
         env:
           INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+          INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
         
       - name: Run Build
         run: yarn build

--- a/integration-tests/hooks.ts
+++ b/integration-tests/hooks.ts
@@ -1,3 +1,4 @@
+import { act } from '@testing-library/react'
 import { abi as MulticallABI } from '@uniswap/v3-periphery/artifacts/contracts/lens/UniswapInterfaceMulticall.sol/UniswapInterfaceMulticall.json'
 import { BigNumber, Contract, providers, utils } from 'ethers'
 import { useEffect, useMemo, useState } from 'react'
@@ -20,7 +21,7 @@ export function useLatestBlock(provider: providers.JsonRpcProvider) {
   const [blockNumber, setBlockNumber] = useState<number | undefined>(undefined)
   useEffect(() => {
     if (!provider) return
-    const onBlock = (num: number) => setBlockNumber(num)
+    const onBlock = (num: number) => act(() => setBlockNumber(num))
     provider.on('block', onBlock)
     return () => {
       provider.off('block', onBlock)
@@ -80,10 +81,15 @@ export function useMaxTokenBalance(chainId: ChainId, blockNumber: number | undef
 
 export function getProvider(chainId: ChainId) {
   if (providerCache[chainId]) return providerCache[chainId]!
-  const infuraKey = process.env.INFURA_PROJECT_ID
-  if (!infuraKey) throw new Error('INFURA_PROJECT_ID is required for provider')
   const name = getInfuraChainName(chainId)
-  providerCache[chainId] = new providers.InfuraProvider(name, infuraKey)
+  const projectId = process.env.INFURA_PROJECT_ID
+  if (!projectId) throw new Error('INFURA_PROJECT_ID is required for provider')
+  const projectSecret = process.env.INFURA_PROJECT_SECRET
+  const project = projectSecret ? {projectId, projectSecret} : projectId
+  providerCache[chainId] = new providers.InfuraProvider(name, project)
+  providerCache[chainId]?.once('error', (e) => {
+    throw e
+  })
   return providerCache[chainId]!
 }
 

--- a/integration-tests/hooks.ts
+++ b/integration-tests/hooks.ts
@@ -85,7 +85,7 @@ export function getProvider(chainId: ChainId) {
   const projectId = process.env.INFURA_PROJECT_ID
   if (!projectId) throw new Error('INFURA_PROJECT_ID is required for provider')
   const projectSecret = process.env.INFURA_PROJECT_SECRET
-  const project = projectSecret ? {projectId, projectSecret} : projectId
+  const project = projectSecret ? { projectId, projectSecret } : projectId
   providerCache[chainId] = new providers.InfuraProvider(name, project)
   providerCache[chainId]?.once('error', (e) => {
     throw e


### PR DESCRIPTION
- Updates the tests to use a project secret (as the requests are server-originated and may not include a referrer)
- Fixes react test to use `act`, fixing a warning during tests
- Throws an error if infura returns a 403, to facilitate remote debugging