### PR TITLE
fix: stabilize call results

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@typechain/ethers-v5": "^7.2.0",
     "@types/jest": "^24.0.25",
     "@types/react": "^17.0.28",
+    "@types/react-dom": "^17.0.14",
     "@uniswap/v3-periphery": "^1.3.0",
     "eslint-plugin-prettier": "3.4.1",
     "ethers": "^5.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/redux-multicall",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A React + Redux lib for fetching and caching chain state via the MultiCall contract",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/hooks.test.tsx
+++ b/src/hooks.test.tsx
@@ -92,7 +92,7 @@ describe('multicall hooks', () => {
         expect(container?.textContent).toBe('a-:0xb')
       })
 
-      it('discards subsequent equivalent data', () => {
+      it('ignores subsequent updates if data is stable', () => {
         function Caller({ call }: { call: Call }) {
           const calls = useMemo(() => [call], [call])
           const data = useCallsDataSubscription(context, 1, calls)
@@ -113,7 +113,12 @@ describe('multicall hooks', () => {
         )
         expect(container?.textContent).toBe('true')
 
+        // stable update
         updateCallResult(call, '0xa')
+        expect(container?.textContent).toBe('true')
+
+        // unrelated update
+        updateCallResult({ address: 'b', callData: '' }, '0xb')
         expect(container?.textContent).toBe('true')
       })
     })

--- a/src/hooks.test.tsx
+++ b/src/hooks.test.tsx
@@ -1,0 +1,82 @@
+import '@testing-library/jest-dom'
+import { combineReducers, configureStore, Store } from '@reduxjs/toolkit'
+import React, { useEffect, useState } from 'react'
+import { render, unmountComponentAtNode } from 'react-dom'
+import { act } from 'react-dom/test-utils'
+import { Provider } from 'react-redux'
+
+import { useCallsDataSubscription } from './hooks'
+import { createMulticallSlice, MulticallActions } from './slice'
+import { toCallKey } from './utils/callKeys'
+
+describe('multicall hooks', () => {
+  let container: HTMLDivElement | null = null
+  let store: Store
+  let actions: MulticallActions
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    const slice = createMulticallSlice('multicall')
+    actions = slice.actions
+    const rootReducer = combineReducers({ multicall: slice.reducer })
+    store = configureStore({ reducer: rootReducer })
+  })
+  afterEach(() => {
+    if (container) {
+      unmountComponentAtNode(container)
+      container.remove()
+    }
+    container = null
+  })
+
+  describe('useCallsDataSubscription', () => {
+    const call = { address: 'abc', callData: '' }
+    const callKey = toCallKey(call)
+    function Caller() {
+      const callResults = useCallsDataSubscription({ reducerPath: 'multicall', actions }, 1, [call])
+      const [count, setCount] = useState(0)
+      useEffect(() => setCount((count) => ++count), [callResults])
+
+      return (
+        <>
+          Data: {callResults[0].data} Count: {count}
+        </>
+      )
+    }
+
+    it('stabilizes values', () => {
+      act(() => {
+        render(
+          <Provider store={store}>
+            <Caller />
+          </Provider>,
+          container
+        )
+      })
+
+      act(() => {
+        store.dispatch(
+          actions.updateMulticallResults({
+            chainId: 1,
+            blockNumber: 1,
+            results: {
+              [callKey]: '0x1',
+            },
+          })
+        )
+        store.dispatch(
+          actions.updateMulticallResults({
+            chainId: 1,
+            blockNumber: 1,
+            results: {
+              [callKey]: '0x1',
+            },
+          })
+        )
+      })
+
+      // expect 2 renders: initial + data available
+      expect(container?.textContent).toBe('Data: 0x1 Count: 2')
+    })
+  })
+})

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -12,7 +12,7 @@ import { isValidMethodArgs, MethodArg } from './validation'
 type OptionalMethodInputs = Array<MethodArg | MethodArg[] | undefined> | undefined
 
 // the lowest level call for subscribing to contract data
-function useCallsDataSubscription(
+export function useCallsDataSubscription(
   context: MulticallContext,
   chainId: number | undefined,
   calls: Array<Call | undefined>,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -66,25 +66,21 @@ export function useCallsDataSubscription(
 
 function useStabilizeCallResults(results: CallResult[]): CallResult[] {
   const [stableResults, setStableResults] = useState(results)
-  useEffect(() => {
-    setStableResults((stableResults) => {
-      if (
-        results.length === stableResults.length &&
-        results.every((result, i) => {
-          const stableResult = stableResults[i]
-          return (
-            result.valid === stableResult.valid &&
-            result.blockNumber === stableResult.blockNumber &&
-            result.data === stableResult.data
-          )
-        })
-      ) {
-        return stableResults
-      }
-      return results
+  const stabilizedResults = useMemo(
+    () => (areEqual(stableResults, results) ? stableResults : results),
+    [results, stableResults]
+  )
+  useEffect(() => setStableResults(stabilizedResults), [stabilizedResults])
+  return stabilizedResults
+}
+
+function areEqual(a: CallResult[], b: CallResult[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every((_, i) => {
+      return a[i].valid === b[i].valid && a[i].blockNumber === b[i].blockNumber && a[i].data === b[i].data
     })
-  }, [results])
-  return stableResults
+  )
 }
 
 // Similar to useCallsDataSubscription above but for subscribing to

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -62,7 +62,7 @@ export function useCallsDataSubscription(
     // ensure that call results arrays remain referentially equivalent when unchanged to prevent
     // spurious re-renders, which would otherwise occur because mapping always creates a new object
     // eslint-disable-next-line
-    [...results]
+    results
   )
 }
 

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -90,6 +90,7 @@ export function createMulticallSlice(reducerPath: string) {
         Object.keys(results).forEach((callKey) => {
           const current = state.callResults[chainId][callKey]
           if ((current?.blockNumber ?? 0) > blockNumber) return
+          if (current?.data === results[callKey] && current?.blockNumber === blockNumber) return
           state.callResults[chainId][callKey] = {
             data: results[callKey],
             blockNumber,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,6 +1766,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/react-dom@^17.0.14":
+  version "17.0.14"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.14.tgz#c8f917156b652ddf807711f5becbd2ab018dea9f"
+  integrity sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-redux@^7.1.16":
   version "7.1.19"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.19.tgz#477bd0a9b01bae6d6bf809418cdfa7d3c16d4c62"


### PR DESCRIPTION
Returns referentially equivalent results unless the results (data, validity, or blocknumber) have actually changed.
Enforcing referential equality prevents spurious re-renders, and avoids blocking the render thread.