### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A React + Redux library for fetching, batching, and caching chain state via the 
 
 ## Setup
 
-`yarn add @uniswap/multicall` or `npm install @uniswap/multicall`
+`yarn add @uniswap/redux-multicall` or `npm install @uniswap/redux-multicall`
 
 ## Usage
 


### PR DESCRIPTION
`@uniswap/multicall` doesn't seem to exist on the registry (https://registry.yarnpkg.com/@uniswap%2fmulticall). So, `yarn add @uniswap/multicall` fails. The same happens with npm