### PR TITLE
doc: rename @uniswap/multicall to @uniswap/redux-multicall

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A React + Redux library for fetching, batching, and caching chain state via the 
 
 ## Setup
 
-`yarn add @uniswap/multicall` or `npm install @uniswap/multicall`
+`yarn add @uniswap/redux-multicall` or `npm install @uniswap/redux-multicall`
 
 ## Usage
 


### PR DESCRIPTION
In npm doc,

`yarn add @uniswap/multicall or npm install @uniswap/multicall`

was there, wherein the package name is `@uniswap/redux-multicall`. This simple typo creates confusion.😭