### PR TITLE
fix: undo mistake making optional options param required in useSingleContractMultipleData hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/redux-multicall",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A React + Redux lib for fetching and caching chain state via the MultiCall contract",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -165,7 +165,7 @@ export function useSingleContractMultipleData(
   contract: Contract | null | undefined,
   methodName: string,
   callInputs: OptionalMethodInputs[],
-  options: Partial<ListenerOptionsWithGas> | undefined
+  options?: Partial<ListenerOptionsWithGas>
 ): CallState[] {
   const { gasRequired } = options ?? {}
 


### PR DESCRIPTION
In last commit, accidentally made options param required in useSingleContractMultipleData. Should remain optional.

Bumped package version up to 1.1.4 to release this fix.