### PR TITLE
feat: memoize inputs array for useSingleCallResult

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -249,8 +249,9 @@ export function useSingleCallResult(
   inputs?: OptionalMethodInputs,
   options?: Partial<ListenerOptionsWithGas>
 ): CallState {
+  const callInputs = useMemo(() => [inputs], [inputs])
   return (
-    useSingleContractMultipleData(context, chainId, latestBlockNumber, contract, methodName, [inputs], options)[0] ??
+    useSingleContractMultipleData(context, chainId, latestBlockNumber, contract, methodName, callInputs, options)[0] ??
     INVALID_CALL_STATE
   )
 }


### PR DESCRIPTION
We were noticing that the return value from `useSingleCallResult` was a new array object on every render. This was essentially passing a new `[inputs]` array object on every render, making the downstream `useMemo` calls obsolete.