### PR TITLE
build: avoid install scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
 
       - run: yarn release
         env:
-          NPM_CONFIG_USERCONFIG: /dev/null
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+          INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
+          NPM_CONFIG_USERCONFIG: /dev/null
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,6 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn postinstall
-      - run: yarn build
-
-      - run: yarn test
-        env:
-          INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
-          INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
-      - run: yarn test:e2e
-        env:
-          INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
-          INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
 
       - run: yarn release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,19 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: yarn install --frozen-lockfile
+      - run: yarn contracts:compile
+
+      - run: yarn test
+        env:
+          INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+          INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
+      - run: yarn test:e2e
+        env:
+          INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+          INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
 
       - run: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
-          INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
           NPM_CONFIG_USERCONFIG: /dev/null
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: yarn install --frozen-lockfile
-      - run: yarn postinstall
 
       - run: yarn release
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,6 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: yarn install --frozen-lockfile
-      - run: yarn postinstall
-      - run: yarn build
 
       - name: Unit tests
         run: yarn test
@@ -34,4 +32,6 @@ jobs:
         env:
           INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
           INFURA_PROJECT_SECRET: ${{ secrets.INFURA_PROJECT_SECRET }}
-        
+
+      - name: Typechecking
+        run: yarn build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: yarn install --frozen-lockfile
+      - run: yarn contracts:compile
 
       - name: Unit tests
         run: yarn test

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   },
   "scripts": {
     "contracts:compile": "typechain --target ethers-v5 --out-dir src/abi/types './node_modules/@uniswap/v3-periphery/artifacts/contracts/**/*Multicall*.json'",
-    "postinstall": "yarn contracts:compile",
     "lint": "tsdx lint .",
     "test": "tsdx test src",
     "test:e2e": "tsdx test integration-tests",
     "build": "tsdx build",
-    "prepublishOnly": "tsdx build",
+    "watch": "tsdx watch",
+    "prepublishOnly": "tsdx test && tsdx build",
     "release": "semantic-release"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:e2e": "tsdx test integration-tests",
     "build": "tsdx build",
     "watch": "tsdx watch",
-    "prepublishOnly": "yarn contracts:compile && tsdx build",
+    "prepublishOnly": "yarn contracts:compile && yarn build",
     "release": "semantic-release"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:e2e": "tsdx test integration-tests",
     "build": "tsdx build",
     "watch": "tsdx watch",
-    "prepublishOnly": "tsdx test && tsdx build",
+    "prepublishOnly": "yarn contracts:compile && tsdx test && tsdx build",
     "release": "semantic-release"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:e2e": "tsdx test integration-tests",
     "build": "tsdx build",
     "watch": "tsdx watch",
-    "prepublishOnly": "yarn contracts:compile && tsdx test && tsdx build",
+    "prepublishOnly": "yarn contracts:compile && tsdx build",
     "release": "semantic-release"
   },
   "devDependencies": {


### PR DESCRIPTION
- Moves final tests/build to `prepublishOnly` (from the release action) - this is [idiomatic for npm](https://docs.npmjs.com/cli/v9/using-npm/scripts#pre--post-scripts:~:text=A%20new%20event%2C%20prepublishOnly%20has%20been%20added%20as%20a%20transitional%20strategy%20to%20allow%20users%20to%20avoid%20the%20confusing%20behavior%20of%20existing%20npm%20versions%20and%20only%20run%20on%20npm%20publish%20(for%20instance%2C%20running%20the%20tests%20one%20last%20time%20to%20ensure%20they%27re%20in%20good%20shape).)
- Removes install scripts (ie `postinstall`), as it also runs when installing the package as a dependency, so it is undesirable for a library package